### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/gcc-cross-builder/security/code-scanning/3](https://github.com/cooljeanius/gcc-cross-builder/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root so all jobs inherit minimal token privileges unless overridden. For this workflow, the least-privilege baseline is:

- `contents: read`

This preserves existing behavior (checkout/read metadata access if needed) while preventing unintended write scopes from defaults.  
Edit `.github/workflows/build.yml` by inserting `permissions:` between the `on:` block and `jobs:` block.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
