### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,6 +3,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/gcc-cross-builder/security/code-scanning/1](https://github.com/cooljeanius/gcc-cross-builder/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define workflow-level permissions with `contents: read`, since all jobs in this file are lint-only and do not need write scopes.

**File to change:** `.github/workflows/pylint.yml`  
**Region:** near the top-level keys, after `on:` (or before `jobs:`).  
**Required changes:** YAML key addition only; no imports, methods, or dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
